### PR TITLE
Configurable interactable layer behavior on selection

### DIFF
--- a/Scripts/InteractionSystem/Editor/Interactions/Interactables/InteractableBaseEditor.cs
+++ b/Scripts/InteractionSystem/Editor/Interactions/Interactables/InteractableBaseEditor.cs
@@ -9,6 +9,7 @@ namespace Shababeek.Interactions.Editors
         // Common serialized properties for all interactables
         private SerializedProperty _interactionHandProp;
         private SerializedProperty _selectionButtonProp;
+        private SerializedProperty _layerBehaviorProp;
 
         // Common event properties
         private SerializedProperty _onSelectedProp;
@@ -34,6 +35,7 @@ namespace Shababeek.Interactions.Editors
             // Find common serialized properties
             _interactionHandProp = serializedObject.FindProperty("interactionHand");
             _selectionButtonProp = serializedObject.FindProperty("selectionButton");
+            _layerBehaviorProp = serializedObject.FindProperty("layerBehavior");
             
             _onSelectedProp = serializedObject.FindProperty("onSelected");
             _onDeselectedProp = serializedObject.FindProperty("onDeselected");
@@ -59,6 +61,8 @@ namespace Shababeek.Interactions.Editors
             DrawInteractionSettings();
             EditorGUILayout.Space();
             DrawCustomProperties();
+            EditorGUILayout.Space();
+            DrawLayeringSettings();
             EditorGUILayout.Space();
             DrawEvents();
             EditorGUILayout.Space();
@@ -105,6 +109,18 @@ namespace Shababeek.Interactions.Editors
         protected virtual void DrawCustomProperties()
         {
             // Override in derived classes to add custom properties
+        }
+
+        private void DrawLayeringSettings()
+        {
+            EditorGUILayout.LabelField("Layering Settings", EditorStyles.boldLabel);
+
+            EditorGUI.indentLevel++;
+            if (_layerBehaviorProp != null)
+            {
+                EditorGUILayout.PropertyField(_layerBehaviorProp, new GUIContent("Layer Behavior", "Whether to assign the layer to this interactable and its children when selected."));
+            }
+            EditorGUI.indentLevel--;
         }
 
         protected virtual void DrawEvents()

--- a/Scripts/InteractionSystem/Runtime/Interactions/Interactables/InteractableBase.cs
+++ b/Scripts/InteractionSystem/Runtime/Interactions/Interactables/InteractableBase.cs
@@ -16,6 +16,12 @@ namespace Shababeek.Interactions
         Right = 2,
     }
 
+    public enum ChangeInteractableLayer
+    {
+        TakeHandLayer = 1,
+        None = 2,
+    }
+
     /// <summary>
     /// Base class for all interactable objects in the interaction system.
     /// Provides the foundation for hover, selection, and activation interactions.
@@ -207,7 +213,7 @@ namespace Shababeek.Interactions
                 DeSelected();
                 isSelected = false;
                 onDeselected.Invoke(currentInteractor);
-                RestoreLayers();
+                    RestoreLayers();
             }
             else if (currentState == InteractionState.Hovering)
             {
@@ -227,7 +233,7 @@ namespace Shababeek.Interactions
                 isSelected = false;
                 onDeselected.Invoke(currentInteractor);
                 DeSelected();
-                RestoreLayers();
+                    RestoreLayers();
             }
 
             currentState = InteractionState.Hovering;
@@ -270,13 +276,13 @@ namespace Shababeek.Interactions
                 {
                     collisionLayers[i] = colliders[i].gameObject.layer;
                 }
-                foreach (var collider in colliders)
-                {
-                    collider.gameObject.layer = currentInteractor.gameObject.layer;
-                }
+                    foreach (var collider in colliders)
+                    {
+                        collider.gameObject.layer = currentInteractor.gameObject.layer;
+                    }
 
-                gameObject.layer = currentInteractor.gameObject.layer;
-            }
+                    gameObject.layer = currentInteractor.gameObject.layer;
+                }
             catch (Exception ee)
             {
                 Debug.LogError(ee, this);

--- a/Scripts/InteractionSystem/Runtime/Interactions/Interactables/InteractableBase.cs
+++ b/Scripts/InteractionSystem/Runtime/Interactions/Interactables/InteractableBase.cs
@@ -37,6 +37,8 @@ namespace Shababeek.Interactions
         [SerializeField]
         private XRButton selectionButton = XRButton.Grip;
 
+        [SerializeField] private ChangeInteractableLayer layerBehavior = ChangeInteractableLayer.TakeHandLayer;
+
         [Header("Interaction Events")]
         [SerializeField]
         public InteractorUnityEvent onSelected = new();
@@ -213,6 +215,7 @@ namespace Shababeek.Interactions
                 DeSelected();
                 isSelected = false;
                 onDeselected.Invoke(currentInteractor);
+                if (layerBehavior == ChangeInteractableLayer.TakeHandLayer)
                     RestoreLayers();
             }
             else if (currentState == InteractionState.Hovering)
@@ -233,6 +236,7 @@ namespace Shababeek.Interactions
                 isSelected = false;
                 onDeselected.Invoke(currentInteractor);
                 DeSelected();
+                if (layerBehavior == ChangeInteractableLayer.TakeHandLayer)
                     RestoreLayers();
             }
 
@@ -276,6 +280,8 @@ namespace Shababeek.Interactions
                 {
                     collisionLayers[i] = colliders[i].gameObject.layer;
                 }
+                if (layerBehavior == ChangeInteractableLayer.TakeHandLayer)
+                {
                     foreach (var collider in colliders)
                     {
                         collider.gameObject.layer = currentInteractor.gameObject.layer;
@@ -283,6 +289,7 @@ namespace Shababeek.Interactions
 
                     gameObject.layer = currentInteractor.gameObject.layer;
                 }
+            }
             catch (Exception ee)
             {
                 Debug.LogError(ee, this);


### PR DESCRIPTION
## Summary

Adds a `ChangeInteractableLayer` enum and a `layerBehavior` field on `InteractableBase` so interactables can either follow the interactor’s layer when selected or keep their existing layers.

## Changes

- **`TakeHandLayer`** (default): On selection, colliders and root use the interactor’s layer; on deselection, layers are restored (existing behavior).
- **`None`**: Skips layer reassignment on selection and does not call `RestoreLayers()` on deselection.

## Editor

`InteractableBaseEditor` includes a **Layering Settings** section with **Layer Behavior** and a tooltip.

## Files

- `Scripts/InteractionSystem/Runtime/Interactions/Interactables/InteractableBase.cs`
- `Scripts/InteractionSystem/Editor/Interactions/Interactables/InteractableBaseEditor.cs`

## Test plan

- [x] Tested locally — behavior works as expected.